### PR TITLE
feat: add AltServer-Linux for automatic iOS app WiFi re-signing

### DIFF
--- a/apps/altserver/manifests/deployment.yaml
+++ b/apps/altserver/manifests/deployment.yaml
@@ -1,25 +1,26 @@
 # AltServer-Linux — automatic WiFi re-signing for sideloaded iOS apps (AltStore).
 #
-# ONE-TIME SETUP (required before this pod is useful):
-#   1. Label the target node:
-#        kubectl label node <node-name> altserver=true
-#      The pod must run on this specific node for USB pairing to work.
+# ONE-TIME SETUP — pair your iPhone on any PC, then copy the file into the pod:
 #
-#   2. Stop host usbmuxd on that node (conflicts with the container's own usbmuxd):
-#        sudo systemctl stop usbmuxd && sudo systemctl disable usbmuxd
+#   On macOS:  brew install libimobiledevice
+#   On Linux:  apt install libimobiledevice-utils
+#   → Plug iPhone into that PC, tap "Trust" on the phone.
+#     The lockdown pairing file appears at:
+#       macOS: /var/db/lockdown/<UDID>.plist
+#       Linux: /var/lib/lockdown/<UDID>.plist
 #
-#   3. Connect iPhone via USB → approve the "Trust This Computer" prompt.
-#      The container's usbmuxd creates the lockdown pairing file automatically.
-#      Check pairing: kubectl exec -n halo deploy/altserver -- ideviceinfo -k DeviceName
+#   Copy it into the running pod (no USB connection to the cluster ever needed):
+#     POD=$(kubectl get pod -n halo -l app=altserver -o jsonpath='{.items[0].metadata.name}')
+#     kubectl cp /var/lib/lockdown/<UDID>.plist halo/$POD:/var/lib/lockdown/<UDID>.plist
 #
-#   4. Install AltStore on the iPhone (one-time, also over USB):
-#        kubectl exec -n halo deploy/altserver -- sh -c \
-#          '/altserver/bin/AltServer -u <UDID> -a <apple-id> -p <password> /altserver/bin/AltStore.ipa'
-#      Find the UDID with: kubectl exec -n halo deploy/altserver -- idevice_id -l
+#   Install AltStore over the same WiFi connection (iPhone and cluster on same LAN):
+#     kubectl exec -n halo deploy/altserver -- sh -c \
+#       '/altserver/bin/AltServer -u <UDID> -a <apple-id> -p <password> /altserver/bin/AltStore.ipa'
+#   Find the UDID with: kubectl exec -n halo deploy/altserver -- idevice_id -l
 #
-#   5. Done. AltStore on the iPhone discovers this server via mDNS and refreshes
-#      all sideloaded apps over WiFi automatically every 7 days.
-#      The lockdown pairing file is persisted in the Longhorn PVC and backed up to S3.
+#   Done. AltStore discovers this server via mDNS and refreshes sideloaded apps
+#   over WiFi automatically every 7 days. The pairing file is persisted in the
+#   Longhorn PVC and backed up to S3, so this step is truly one-time.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -43,15 +44,6 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
         - name: regcred
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: altserver
-                    operator: In
-                    values:
-                      - "true"
       containers:
         - name: altserver
           # dreth/altserver-docker is a self-contained image managed by supervisord that runs:
@@ -64,10 +56,13 @@ spec:
             - name: ALLOW_PROVISION_TO_DOWNLOAD_LIBS
               value: "true"
           securityContext:
-            privileged: true
+            capabilities:
+              add:
+                - NET_ADMIN  # avahi: join multicast group 224.0.0.251 for mDNS
+                - NET_RAW    # avahi: raw socket for mDNS packet handling
           volumeMounts:
-            # iOS device pairing records — MUST persist. Created when the iPhone first
-            # trusts this server over USB. Losing these requires re-pairing via USB.
+            # iOS device pairing records — MUST persist. Copied in once from your PC.
+            # Losing these requires re-copying from your PC (or re-pairing via USB).
             - mountPath: /var/lib/lockdown
               name: altserver-data
               subPath: lockdown
@@ -81,10 +76,6 @@ spec:
             - mountPath: /altserver/bin
               name: altserver-data
               subPath: bin
-            # USB device tree — needed for the one-time pairing step.
-            # After pairing, WiFi refresh works without USB being connected.
-            - mountPath: /dev/bus/usb
-              name: usb-devices
           resources:
             requests:
               cpu: "100m"
@@ -96,7 +87,3 @@ spec:
         - name: altserver-data
           persistentVolumeClaim:
             claimName: altserver-data
-        - name: usb-devices
-          hostPath:
-            path: /dev/bus/usb
-            type: Directory

--- a/apps/altserver/manifests/deployment.yaml
+++ b/apps/altserver/manifests/deployment.yaml
@@ -1,0 +1,102 @@
+# AltServer-Linux — automatic WiFi re-signing for sideloaded iOS apps (AltStore).
+#
+# ONE-TIME SETUP (required before this pod is useful):
+#   1. Label the target node:
+#        kubectl label node <node-name> altserver=true
+#      The pod must run on this specific node for USB pairing to work.
+#
+#   2. Stop host usbmuxd on that node (conflicts with the container's own usbmuxd):
+#        sudo systemctl stop usbmuxd && sudo systemctl disable usbmuxd
+#
+#   3. Connect iPhone via USB → approve the "Trust This Computer" prompt.
+#      The container's usbmuxd creates the lockdown pairing file automatically.
+#      Check pairing: kubectl exec -n halo deploy/altserver -- ideviceinfo -k DeviceName
+#
+#   4. Install AltStore on the iPhone (one-time, also over USB):
+#        kubectl exec -n halo deploy/altserver -- sh -c \
+#          '/altserver/bin/AltServer -u <UDID> -a <apple-id> -p <password> /altserver/bin/AltStore.ipa'
+#      Find the UDID with: kubectl exec -n halo deploy/altserver -- idevice_id -l
+#
+#   5. Done. AltStore on the iPhone discovers this server via mDNS and refreshes
+#      all sideloaded apps over WiFi automatically every 7 days.
+#      The lockdown pairing file is persisted in the Longhorn PVC and backed up to S3.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: altserver
+  namespace: halo
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: altserver
+  template:
+    metadata:
+      labels:
+        app: altserver
+    spec:
+      # hostNetwork is required so avahi-daemon can broadcast _altserver._tcp mDNS
+      # on the LAN (192.168.8.x), allowing iOS devices to auto-discover this server.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      imagePullSecrets:
+        - name: regcred
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: altserver
+                    operator: In
+                    values:
+                      - "true"
+      containers:
+        - name: altserver
+          # dreth/altserver-docker is a self-contained image managed by supervisord that runs:
+          # avahi-daemon (mDNS), usbmuxd (device comms), anisette-server (Apple auth, :6969),
+          # and AltServer itself. Binaries are downloaded from GitHub on first start.
+          image: dreth/altserver-docker:latest
+          imagePullPolicy: Always
+          env:
+            # Allow downloading Apple Provision libraries on first start (needed for anisette).
+            - name: ALLOW_PROVISION_TO_DOWNLOAD_LIBS
+              value: "true"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            # iOS device pairing records — MUST persist. Created when the iPhone first
+            # trusts this server over USB. Losing these requires re-pairing via USB.
+            - mountPath: /var/lib/lockdown
+              name: altserver-data
+              subPath: lockdown
+            # Apple Provision libraries for the anisette server.
+            # Persisted to avoid a multi-minute re-download on every pod restart.
+            - mountPath: /root/.config/Provision/lib
+              name: altserver-data
+              subPath: provision-lib
+            # AltServer + netmuxd + anisette binaries downloaded at first start.
+            # Persisted so restarts are fast (no re-download from GitHub releases).
+            - mountPath: /altserver/bin
+              name: altserver-data
+              subPath: bin
+            # USB device tree — needed for the one-time pairing step.
+            # After pairing, WiFi refresh works without USB being connected.
+            - mountPath: /dev/bus/usb
+              name: usb-devices
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+      volumes:
+        - name: altserver-data
+          persistentVolumeClaim:
+            claimName: altserver-data
+        - name: usb-devices
+          hostPath:
+            path: /dev/bus/usb
+            type: Directory

--- a/apps/altserver/manifests/pvc.yaml
+++ b/apps/altserver/manifests/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: altserver-data
+  namespace: halo
+  labels:
+    # Back up lockdown pairing files — losing them means re-pairing the iPhone via USB.
+    recurring-job-group.longhorn.io/default: "enabled"
+    recurring-job.longhorn.io/s3-monthly-backup: "enabled"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn

--- a/infrastructure/argocd/argocd-manifests-applicationset.yaml
+++ b/infrastructure/argocd/argocd-manifests-applicationset.yaml
@@ -46,8 +46,11 @@ spec:
           - name: n8n-app
             path: ./apps/n8n
             namespace: halo
-          - name: immich-app          
+          - name: immich-app
             path: ./apps/immich
+            namespace: halo
+          - name: altserver-app
+            path: ./apps/altserver/manifests
             namespace: halo
           - name: metallb
             path: ./infrastructure/metallb/manifests


### PR DESCRIPTION
## Summary

- Adds `apps/altserver/manifests/` with a Deployment and PVC for AltServer-Linux
- Registers the app in the ArgoCD manifest ApplicationSet so it syncs automatically
- Uses `dreth/altserver-docker` — a supervisord-managed image that bundles avahi-daemon (mDNS), usbmuxd (device comms), an anisette server (Apple auth), and AltServer itself
- After a one-time lockdown file copy (no USB to the cluster needed), AltStore on the iPhone discovers this server via mDNS and refreshes all sideloaded apps (e.g. YTLite) over WiFi every 7 days — no Mac/PC involved after that

## Architecture decisions

**`hostNetwork: true`** — avahi must broadcast `_altserver._tcp` mDNS on the real LAN (192.168.8.x) so iOS devices auto-discover the server. Without this, mDNS stays inside the pod network and the iPhone never finds it.

**`NET_ADMIN` + `NET_RAW` capabilities** — the minimum needed for avahi-daemon to join multicast group 224.0.0.251 and handle mDNS packets. No `privileged: true` required.

**No node affinity, no USB mount** — the lockdown pairing file is generated once on any PC with `libimobiledevice` and copied into the pod via `kubectl cp`. The cluster never needs a USB cable connected to it.

**2 Gi Longhorn PVC (backed up to S3)** — stores three things via subPaths:
- `lockdown/` → `/var/lib/lockdown` — iOS pairing records (critical; losing these just means re-copying from your PC)
- `provision-lib/` → `/root/.config/Provision/lib` — Apple Provision libraries for anisette auth
- `bin/` → `/altserver/bin` — cached binaries so pod restarts don't re-download from GitHub

## One-time setup steps (after merging and ArgoCD syncs)

```bash
# 1. On your Mac or any Linux machine — install libimobiledevice:
#    macOS:  brew install libimobiledevice
#    Linux:  apt install libimobiledevice-utils

# 2. Plug iPhone into that machine, tap "Trust This Computer" on the phone.
#    The lockdown pairing file appears at:
#      macOS: /var/db/lockdown/<UDID>.plist
#      Linux: /var/lib/lockdown/<UDID>.plist

# 3. Copy it into the pod (cluster never needs USB):
POD=$(kubectl get pod -n halo -l app=altserver -o jsonpath='{.items[0].metadata.name}')
kubectl cp /var/lib/lockdown/<UDID>.plist halo/$POD:/var/lib/lockdown/<UDID>.plist

# 4. Find UDID and install AltStore (iPhone and cluster on same WiFi):
kubectl exec -n halo deploy/altserver -- idevice_id -l
kubectl exec -n halo deploy/altserver -- sh -c \
  '/altserver/bin/AltServer -u <UDID> -a <apple-id> -p <password> /altserver/bin/AltStore.ipa'

# 5. Done. AltStore auto-refreshes over WiFi from here on.
#    The pairing file is persisted in Longhorn + backed up to S3 — truly one-time.
```

## Why not SideStore?

SideStore was evaluated as a simpler alternative (no privileged container, no USB mount) but rejected for this setup because:
- It occupies the iOS VPN slot, conflicting with WireGuard/Tailscale already in use on the phone (`fabseMobile` peer)
- Its pairing files expire randomly (sometimes within days), requiring recurring USB reconnects — worse than AltServer's one-time copy
- It breaks more frequently on iOS updates than AltServer's mature iTunes/AFC protocol

## Test plan

- [ ] Confirm pod schedules and reaches Running state (no node label required)
- [ ] Check logs show avahi + usbmuxd + anisette starting via supervisord
- [ ] Pair iPhone on a local machine, copy lockdown file in, verify with `idevice_id -l`
- [ ] Install AltStore via `kubectl exec`, confirm it appears on the iPhone
- [ ] Disconnect USB from PC, confirm AltStore discovers the server over WiFi
- [ ] Trigger a manual refresh in AltStore → apps re-signed without any cable

https://claude.ai/code/session_016ueaPEJPGh37mPB5k8PF3a