### PR TITLE
fix(altserver): replace amd64-only image with ARM64 multi-container setup

### DIFF
--- a/apps/altserver/manifests/deployment.yaml
+++ b/apps/altserver/manifests/deployment.yaml
@@ -13,14 +13,23 @@
 #     POD=$(kubectl get pod -n halo -l app=altserver -o jsonpath='{.items[0].metadata.name}')
 #     kubectl cp /var/lib/lockdown/<UDID>.plist halo/$POD:/var/lib/lockdown/<UDID>.plist
 #
-#   Install AltStore over the same WiFi connection (iPhone and cluster on same LAN):
-#     kubectl exec -n halo deploy/altserver -- sh -c \
-#       '/altserver/bin/AltServer -u <UDID> -a <apple-id> -p <password> /altserver/bin/AltStore.ipa'
-#   Find the UDID with: kubectl exec -n halo deploy/altserver -- idevice_id -l
+#   Find the AltServer binary path and install AltStore (iPhone and cluster on same LAN):
+#     kubectl exec -n halo deploy/altserver -c altserver -- find / -name AltServer -type f 2>/dev/null
+#     kubectl exec -n halo deploy/altserver -c altserver -- \
+#       <path/to/AltServer> -u <UDID> -a <apple-id> -p <password> <path/to/AltStore.ipa>
+#   Find the UDID with: kubectl exec -n halo deploy/altserver -c altserver -- idevice_id -l
 #
 #   Done. AltStore discovers this server via mDNS and refreshes sideloaded apps
 #   over WiFi automatically every 7 days. The pairing file is persisted in the
 #   Longhorn PVC and backed up to S3, so this step is truly one-time.
+#
+# Three containers in this pod:
+#   avahi     — advertises _altserver._tcp via mDNS so iOS devices auto-discover the server
+#   altserver — AltServer-Linux + netmuxd (aizhihuxiao/gta-altserver, ARM64)
+#   anisette  — Apple authentication token server (dadoum/anisette-v3-server, ARM64)
+#
+# avahi and altserver share a D-Bus socket via an emptyDir so avahi-daemon's mDNS
+# registrations are visible to the AltServer process in the sibling container.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,52 +47,97 @@ spec:
       labels:
         app: altserver
     spec:
-      # hostNetwork is required so avahi-daemon can broadcast _altserver._tcp mDNS
-      # on the LAN (192.168.8.x), allowing iOS devices to auto-discover this server.
+      # hostNetwork is required so avahi broadcasts _altserver._tcp mDNS on the real
+      # LAN (192.168.8.x), allowing iOS devices to auto-discover this server.
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
         - name: regcred
       containers:
-        - name: altserver
-          # dreth/altserver-docker is a self-contained image managed by supervisord that runs:
-          # avahi-daemon (mDNS), usbmuxd (device comms), anisette-server (Apple auth, :6969),
-          # and AltServer itself. Binaries are downloaded from GitHub on first start.
-          image: dreth/altserver-docker:latest
-          imagePullPolicy: Always
-          env:
-            # Allow downloading Apple Provision libraries on first start (needed for anisette).
-            - name: ALLOW_PROVISION_TO_DOWNLOAD_LIBS
-              value: "true"
+        # ── avahi ──────────────────────────────────────────────────────────────
+        # Installs dbus + avahi-daemon on first start (~30 s), then broadcasts
+        # the _altserver._tcp mDNS service on the LAN. The D-Bus socket is
+        # written to the shared dbus-socket emptyDir so the altserver container
+        # can register its service via the standard DBUS_SYSTEM_BUS_ADDRESS env var.
+        - name: avahi
+          image: debian:bookworm-slim
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              apt-get update -qq && apt-get install -y -qq avahi-daemon dbus
+              mkdir -p /run/dbus /var/run/avahi-daemon
+              dbus-daemon --system --fork
+              exec avahi-daemon --no-drop-root --no-chroot
           securityContext:
             capabilities:
               add:
-                - NET_ADMIN  # avahi: join multicast group 224.0.0.251 for mDNS
-                - NET_RAW    # avahi: raw socket for mDNS packet handling
+                - NET_ADMIN  # join multicast group 224.0.0.251
+                - NET_RAW    # raw socket for mDNS packets
+          volumeMounts:
+            - name: dbus-socket
+              mountPath: /run/dbus
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
+
+        # ── altserver ──────────────────────────────────────────────────────────
+        # ARM64 image (aizhihuxiao/gta-altserver) with AltServer-Linux + netmuxd.
+        # netmuxd provides a local usbmuxd-compatible socket that routes device
+        # connections over WiFi instead of USB.
+        - name: altserver
+          image: aizhihuxiao/gta-altserver:latest
+          imagePullPolicy: Always
+          env:
+            - name: ALTSERVER_ANISETTE_SERVER
+              value: "http://localhost:6969"
+            # Point libavahi (used by AltServer) to the shared D-Bus socket
+            # started by the avahi sidecar.
+            - name: DBUS_SYSTEM_BUS_ADDRESS
+              value: "unix:path=/run/dbus/system_bus_socket"
           volumeMounts:
             # iOS device pairing records — MUST persist. Copied in once from your PC.
-            # Losing these requires re-copying from your PC (or re-pairing via USB).
             - mountPath: /var/lib/lockdown
               name: altserver-data
               subPath: lockdown
-            # Apple Provision libraries for the anisette server.
-            # Persisted to avoid a multi-minute re-download on every pod restart.
-            - mountPath: /root/.config/Provision/lib
-              name: altserver-data
-              subPath: provision-lib
-            # AltServer + netmuxd + anisette binaries downloaded at first start.
-            # Persisted so restarts are fast (no re-download from GitHub releases).
-            - mountPath: /altserver/bin
-              name: altserver-data
-              subPath: bin
+            # Shared D-Bus socket so AltServer can reach the avahi sidecar.
+            - name: dbus-socket
+              mountPath: /run/dbus
           resources:
             requests:
               cpu: "100m"
-              memory: "256Mi"
+              memory: "128Mi"
             limits:
               cpu: "500m"
-              memory: "512Mi"
+              memory: "256Mi"
+
+        # ── anisette ───────────────────────────────────────────────────────────
+        # Generates Apple authentication tokens used during app signing/refresh.
+        # AltServer hits this on localhost:6969 for every signing operation.
+        # Self-hosting avoids Apple ID lockouts caused by shared public servers.
+        - name: anisette
+          image: dadoum/anisette-v3-server:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            # Persist anisette provisioning data so Apple auth survives pod restarts.
+            - mountPath: /home/Alcoholic/.config/anisette-v3/lib
+              name: altserver-data
+              subPath: anisette-lib
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+
       volumes:
         - name: altserver-data
           persistentVolumeClaim:
             claimName: altserver-data
+        # Shared D-Bus socket between avahi and altserver containers.
+        - name: dbus-socket
+          emptyDir: {}

--- a/apps/altserver/manifests/pvc.yaml
+++ b/apps/altserver/manifests/pvc.yaml
@@ -4,7 +4,8 @@ metadata:
   name: altserver-data
   namespace: halo
   labels:
-    # Back up lockdown pairing files — losing them means re-pairing the iPhone via USB.
+    # Back up lockdown pairing files and anisette provisioning data.
+    # Losing lockdown/ means re-copying the pairing file from your PC.
     recurring-job-group.longhorn.io/default: "enabled"
     recurring-job.longhorn.io/s3-monthly-backup: "enabled"
 spec:
@@ -12,5 +13,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
+      storage: 1Gi
   storageClassName: longhorn


### PR DESCRIPTION
## Problem

`dreth/altserver-docker` is amd64-only. On the ARM64 cluster it immediately throws an **exec format error** and the pod never starts.

## Solution

Replace the single `dreth` container with three ARM64-compatible containers in the same pod:

| Container | Image | Role |
|---|---|---|
| `avahi` | `debian:bookworm-slim` | starts dbus-daemon + avahi-daemon, broadcasts `_altserver._tcp` mDNS on the LAN |
| `altserver` | `aizhihuxiao/gta-altserver:latest` | AltServer-Linux + netmuxd (ARM64, ~55 MB, maintained Mar 2026) |
| `anisette` | `dadoum/anisette-v3-server:latest` | Apple auth token server on localhost:6969 (ARM64 confirmed) |

## Key design detail — shared D-Bus socket

avahi-daemon and AltServer live in separate containers and normally can't reach each other's D-Bus. The fix introduces a shared `emptyDir` volume mounted at `/run/dbus` in both containers. avahi starts `dbus-daemon` into that volume; AltServer is pointed to it via `DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket`. This lets AltServer register its mDNS service through the avahi sidecar.

## Other changes

- PVC reduced from 2 Gi → 1 Gi: the `aizhihuxiao` image has binaries baked in, so the `bin/` subPath cache is no longer needed
- `NET_ADMIN` + `NET_RAW` capabilities moved to the `avahi` container only (the other two need none)
- `ALTSERVER_ANISETTE_SERVER=http://localhost:6969` wires AltServer to the anisette sidecar

## One caveat

The `avahi` container runs `apt-get install avahi-daemon dbus` on first start (~30 s). This only happens on pod creation/restart — subsequent starts skip the install because the packages are already cached in the container's writable layer.

## Test plan

- [ ] Pod reaches Running (all 3 containers) — no exec format error
- [ ] `kubectl logs -n halo deploy/altserver -c avahi` shows avahi-daemon started
- [ ] `kubectl logs -n halo deploy/altserver -c anisette` shows listening on :6969
- [ ] Copy lockdown file in, verify with `kubectl exec … -c altserver -- idevice_id -l`
- [ ] Install AltStore, confirm WiFi discovery and refresh works

https://claude.ai/code/session_016ueaPEJPGh37mPB5k8PF3a

---
_Generated by [Claude Code](https://claude.ai/code/session_016ueaPEJPGh37mPB5k8PF3a)_