### PR TITLE
fix(altserver): increase anisette memory limit to 512Mi

### DIFF
--- a/apps/altserver/manifests/deployment.yaml
+++ b/apps/altserver/manifests/deployment.yaml
@@ -129,10 +129,10 @@ spec:
           resources:
             requests:
               cpu: "50m"
-              memory: "64Mi"
+              memory: "256Mi"
             limits:
               cpu: "200m"
-              memory: "128Mi"
+              memory: "512Mi"
 
       volumes:
         - name: altserver-data


### PR DESCRIPTION
## Problem

The `anisette` container is CrashLoopBackOff with exit code 137 (OOMKilled). The `dadoum/anisette-v3-server` loads Apple Provision libraries on startup which is memory-heavy — the previous 128 Mi limit wasn't enough.

## Change

```
anisette memory request: 64Mi  → 256Mi
anisette memory limit:  128Mi  → 512Mi
```

## Test plan
- [ ] Merge → ArgoCD syncs → anisette container stays Running (no OOMKilled)

https://claude.ai/code/session_016ueaPEJPGh37mPB5k8PF3a

---
_Generated by [Claude Code](https://claude.ai/code/session_016ueaPEJPGh37mPB5k8PF3a)_