### PR TITLE
fix(altserver): chmod anisette-lib on startup to fix Permission denied

### DIFF
--- a/apps/altserver/manifests/deployment.yaml
+++ b/apps/altserver/manifests/deployment.yaml
@@ -53,6 +53,17 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
         - name: regcred
+      initContainers:
+        # The anisette-v3-server runs as non-root user 'Alcoholic'. Longhorn mounts
+        # PVC subPaths as root:root, so the container can't read its own lib files
+        # on restarts. This init container fixes ownership before anything starts.
+        - name: fix-anisette-permissions
+          image: busybox:1.36-musl
+          command: ["sh", "-c", "chmod -R 755 /anisette-lib"]
+          volumeMounts:
+            - name: altserver-data
+              mountPath: /anisette-lib
+              subPath: anisette-lib
       containers:
         # ── avahi ──────────────────────────────────────────────────────────────
         # Installs dbus + avahi-daemon on first start (~30 s), then broadcasts


### PR DESCRIPTION
## Problem

```
std.file.FileException@std/file.d(836): /home/Alcoholic/.config/anisette-v3/lib/libCoreADI.so: Permission denied
```

`dadoum/anisette-v3-server` runs as a non-root user (`Alcoholic`). Longhorn mounts PVC subPaths as `root:root` by default. On the first start the container downloads and writes `libCoreADI.so` and friends — but on any subsequent pod restart those files are owned by root and the non-root user inside the container can't read them.

## Fix

Add an `initContainer` (`busybox`) that runs `chmod -R 755 /anisette-lib` against the subPath before any main container starts. This makes the library files world-readable regardless of which UID owns them, without needing to know the exact UID of `Alcoholic` inside the image.

## Test plan
- [ ] Merge → ArgoCD syncs → anisette container starts and stays Running
- [ ] `kubectl logs -n halo deploy/altserver -c anisette` shows the server listening on :6969

https://claude.ai/code/session_016ueaPEJPGh37mPB5k8PF3a

---
_Generated by [Claude Code](https://claude.ai/code/session_016ueaPEJPGh37mPB5k8PF3a)_