### PR TITLE
fix(altserver): use emptyDir for anisette lib to fix Permission denied without running as root

### DIFF
--- a/apps/altserver/manifests/deployment.yaml
+++ b/apps/altserver/manifests/deployment.yaml
@@ -118,19 +118,18 @@ spec:
         # Generates Apple authentication tokens used during app signing/refresh.
         # AltServer hits this on localhost:6969 for every signing operation.
         # Self-hosting avoids Apple ID lockouts caused by shared public servers.
-        # runAsUser: 0 — Apple's library archive embeds restrictive permissions
-        # (files end up unreadable by the non-root 'Alcoholic' user on Longhorn
-        # volumes). Running as root sidesteps this without any other side effects.
         - name: anisette
           image: dadoum/anisette-v3-server:latest
           imagePullPolicy: Always
-          securityContext:
-            runAsUser: 0
           volumeMounts:
-            # Persist anisette provisioning data so Apple auth survives pod restarts.
+            # Apple Provision libraries (libCoreADI.so etc.) are stored on an
+            # emptyDir rather than the Longhorn PVC. Longhorn mounts subPaths as
+            # root:root, which causes Permission denied when the non-root
+            # 'Alcoholic' user tries to read files extracted from Apple's archive.
+            # emptyDir has no such restriction. Downside: ~30 s re-download on
+            # every pod restart, which is acceptable for a home cluster.
             - mountPath: /home/Alcoholic/.config/anisette-v3/lib
-              name: altserver-data
-              subPath: anisette-lib
+              name: anisette-lib
           resources:
             requests:
               cpu: "50m"
@@ -145,4 +144,8 @@ spec:
             claimName: altserver-data
         # Shared D-Bus socket between avahi and altserver containers.
         - name: dbus-socket
+          emptyDir: {}
+        # Ephemeral storage for Apple Provision libraries — re-downloaded on each
+        # pod start. Using emptyDir avoids Longhorn's root:root ownership problem.
+        - name: anisette-lib
           emptyDir: {}

--- a/apps/altserver/manifests/deployment.yaml
+++ b/apps/altserver/manifests/deployment.yaml
@@ -53,17 +53,6 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       imagePullSecrets:
         - name: regcred
-      initContainers:
-        # The anisette-v3-server runs as non-root user 'Alcoholic'. Longhorn mounts
-        # PVC subPaths as root:root, so the container can't read its own lib files
-        # on restarts. This init container fixes ownership before anything starts.
-        - name: fix-anisette-permissions
-          image: busybox:1.36-musl
-          command: ["sh", "-c", "chmod -R 755 /anisette-lib"]
-          volumeMounts:
-            - name: altserver-data
-              mountPath: /anisette-lib
-              subPath: anisette-lib
       containers:
         # ── avahi ──────────────────────────────────────────────────────────────
         # Installs dbus + avahi-daemon on first start (~30 s), then broadcasts
@@ -129,9 +118,14 @@ spec:
         # Generates Apple authentication tokens used during app signing/refresh.
         # AltServer hits this on localhost:6969 for every signing operation.
         # Self-hosting avoids Apple ID lockouts caused by shared public servers.
+        # runAsUser: 0 — Apple's library archive embeds restrictive permissions
+        # (files end up unreadable by the non-root 'Alcoholic' user on Longhorn
+        # volumes). Running as root sidesteps this without any other side effects.
         - name: anisette
           image: dadoum/anisette-v3-server:latest
           imagePullPolicy: Always
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             # Persist anisette provisioning data so Apple auth survives pod restarts.
             - mountPath: /home/Alcoholic/.config/anisette-v3/lib


### PR DESCRIPTION
## Problem

Apple's Provision library archive embeds restrictive file permissions. When `dadoum/anisette-v3-server` extracts `libCoreADI.so` onto a Longhorn-backed PVC subPath (which is mounted `root:root`), the non-root `Alcoholic` user inside the container can't read the files it just wrote — hence `Permission denied`.

A previous attempt used `runAsUser: 0` to work around this, but running as root in a container with `hostNetwork: true` is an unnecessary security risk for a home cluster.

## Fix

Mount `/home/Alcoholic/.config/anisette-v3/lib` as an `emptyDir` instead of a Longhorn PVC subPath. `emptyDir` has no ownership restrictions, so the container user can freely write and read the extracted `.so` files.

**Tradeoff:** The Apple libraries (~70 MB) are re-downloaded from Apple's servers on every pod restart (~30 s). Acceptable for a home cluster.

The Longhorn PVC is now used exclusively for the iOS device lockdown pairing files.

## Test plan
- [ ] Merge → ArgoCD syncs → anisette container starts and stays Running as non-root
- [ ] `kubectl logs -n halo deploy/altserver -c anisette` shows listening on :6969 without Permission denied

https://claude.ai/code/session_016ueaPEJPGh37mPB5k8PF3a