### PR TITLE
fix: bump renovatebot/github-action from v41 to v46.1.15

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: renovatebot/github-action@v41
+      - uses: renovatebot/github-action@v46.1.15
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `renovatebot/github-action@v41` does not exist as a published tag, causing the workflow to fail with _"unable to find version `v41`"_
- Updated to `v46.1.15`, the latest release as of 2026-06-09 (confirmed via the [releases page](https://github.com/renovatebot/github-action/releases))
- No floating major-version tags (e.g. `v46`) exist for this action, so the full semver tag is used

## Test plan

- [ ] Trigger the Renovate workflow manually via `workflow_dispatch` and confirm it runs without the version-resolution error

https://claude.ai/code/session_013gG5R91o4ofhgCeBTXLt1P

---
_Generated by [Claude Code](https://claude.ai/code/session_013gG5R91o4ofhgCeBTXLt1P)_