### PR TITLE
fix: add renovate global config so Renovate finds the repository

### DIFF
--- a/.github/renovate-global-config.json
+++ b/.github/renovate-global-config.json
@@ -1,4 +1,5 @@
 {
+  "platform": "github",
   "repositories": ["orazefabian/homecluster"],
   "onboarding": false,
   "requireConfig": "optional"

--- a/.github/renovate-global-config.json
+++ b/.github/renovate-global-config.json
@@ -1,0 +1,5 @@
+{
+  "repositories": ["orazefabian/homecluster"],
+  "onboarding": false,
+  "requireConfig": "optional"
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: renovatebot/github-action@v46.1.15
         with:
           configurationFile: .github/renovate-global-config.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,4 +17,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: renovatebot/github-action@v46.1.15
         with:
+          configurationFile: .github/renovate-global-config.json
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

After the action version was fixed, Renovate still exits with:
```
WARN: No repositories found - did you want to run with flag --autodiscover?
```

Self-hosted Renovate requires a **global config** that tells it which repositories to manage. Without it, Renovate starts up but has no work to do.

## Root causes (verified against official docs + example config)

**1. Missing global config with `repositories`**
The `renovate.json` in the repo root is the *per-repo* config. Self-hosted Renovate needs a separate global config specifying which repos to manage. Added `.github/renovate-global-config.json`.

**2. Missing `platform: "github"`**
The official example config (`example/renovate-config.json` in the action repo) always includes `"platform": "github"`. Without it Renovate may not know which platform API to use.

**3. `GITHUB_TOKEN` is explicitly unsupported**
The action README states:
> "the built-in `GITHUB_TOKEN` cannot be used because it has too restrictive permissions and pull requests created with it do not trigger your Pull Request and Push CI events."
Switched to `secrets.RENOVATE_TOKEN`.

## Changes

**New file: `.github/renovate-global-config.json`**
```json
{
  "platform": "github",
  "repositories": ["orazefabian/homecluster"],
  "onboarding": false,
  "requireConfig": "optional"
}
```

**Updated: `.github/workflows/renovate.yml`**
- Added `configurationFile: .github/renovate-global-config.json`
- Changed token from `GITHUB_TOKEN` → `RENOVATE_TOKEN`

## Required manual step before merging

Create a classic PAT with `repo` scope and add it as a repository secret named **`RENOVATE_TOKEN`**:
> Settings → Secrets and variables → Actions → New repository secret

## Test plan

- [ ] Add `RENOVATE_TOKEN` secret to the repo
- [ ] Trigger via `workflow_dispatch` and confirm the "No repositories found" warning is gone
- [ ] Confirm Renovate scans `orazefabian/homecluster` and opens dependency PRs as expected

https://claude.ai/code/session_013gG5R91o4ofhgCeBTXLt1P