### PR TITLE
feat(anisette): add SideStore public server as fallback

### DIFF
--- a/apps/anisette/manifests/deployment.yaml
+++ b/apps/anisette/manifests/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: anisette
+      annotations:
+        reloader.stakater.com/auto: "true"
     spec:
       containers:
         - name: anisette

--- a/apps/anisette/manifests/serverlist-configmap.yaml
+++ b/apps/anisette/manifests/serverlist-configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: anisette-server-list
   namespace: halo
 data:
-  servers.json: '{"servers":[{"name":"Home Cluster","address":"https://anisette.halo.fabseit.net"}]}'
+  servers.json: '{"servers":[{"name":"Home Cluster","address":"https://anisette.halo.fabseit.net"},{"name":"SideStore","address":"https://ani.sidestore.io"}]}'


### PR DESCRIPTION
## Summary

- Adds the official SideStore anisette server (`https://ani.sidestore.io`) as a second entry in the `anisette-server-list` ConfigMap
- The home cluster server remains the primary; the public server acts as automatic fallback

## Problem

When away from home, SideStore needs the private anisette server at `anisette.halo.fabseit.net`, but reaching it requires **both** Tailscale/Headscale and the loopback dev VPN active simultaneously — an awkward combination. With only one server in the list, SideStore fails entirely when the private server is unreachable.

## Solution

SideStore (v0.5.8+) iterates through the server list and automatically falls back to the next entry when a server is unreachable (with a toast notification shown to the user since v0.5.9).

The chosen fallback `https://ani.sidestore.io` is the **official SideStore-maintained** v3/omnisette server — the same protocol (`dadoum/anisette-v3-server`) as the private cluster server.

## Test plan

- [ ] Verify ArgoCD syncs the updated ConfigMap without issues
- [ ] Confirm SideStore still uses the home cluster server when on the local network
- [ ] Confirm SideStore falls back to `ani.sidestore.io` when the private server is unreachable (e.g., away from home without VPN active)

https://claude.ai/code/session_01HXwBz1vuCnAWatbrHsVhY8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXwBz1vuCnAWatbrHsVhY8)_