### PR TITLE
Preserve resources when an app leaves an ApplicationSet

### DIFF
--- a/infrastructure/argocd/argocd-helm-applicationset.yaml
+++ b/infrastructure/argocd/argocd-helm-applicationset.yaml
@@ -4,6 +4,12 @@ metadata:
   name: helm-applicationset
   namespace: argocd
 spec:
+  # See the matching comment in argocd-manifests-applicationset.yaml. This one
+  # matters more: the charts here own CRDs (Longhorn, cert-manager,
+  # kube-prometheus-stack), so a cascade delete would take the CRs with them —
+  # volumes, issuers, address pools.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   ignoreApplicationDifferences:
     - jsonPointers:
       - /spec/syncPolicy

--- a/infrastructure/argocd/argocd-manifests-applicationset.yaml
+++ b/infrastructure/argocd/argocd-manifests-applicationset.yaml
@@ -4,6 +4,17 @@ metadata:
   name: manifests-applicationset
   namespace: argocd
 spec:
+  # Without this the ApplicationSet controller stamps
+  # resources-finalizer.argocd.argoproj.io onto every generated Application,
+  # so removing an entry from the list below cascade-deletes that app's live
+  # resources — including CRDs, and with them any CRs of those types. That
+  # contradicts the repo-wide `prune: false` stance and cannot be worked
+  # around by patching the finalizer off an Application, since the controller
+  # immediately re-adds it. With this set, removing an entry deletes only the
+  # Application object and orphans the resources, which is the intended
+  # behaviour here.
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   ignoreApplicationDifferences:
     - jsonPointers:
       - /spec/syncPolicy


### PR DESCRIPTION
The ApplicationSet controller stamps
resources-finalizer.argocd.argoproj.io onto every Application it generates unless preserveResourcesOnDeletion is set. Removing an entry from a generator list therefore cascade-deletes that app's live resources rather than just the Application object — including CRDs, and with them every CR of those types.

That directly contradicts the repo-wide `prune: false` stance, and it is invisible until it fires: the finalizer appears on no manifest in this repo, only on the generated Applications in-cluster. Patching it off an Application does not work either, since the controller re-adds it on the next reconcile.

Split out as its own commit so the effect can be verified — every generated Application's finalizer list should empty out — before anything depends on it.